### PR TITLE
Add "ES" to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Connects to the Kodi Connect Server to:
 ## Beta testing
 At the moment, the skill is not certified, and is in Beta testing, so you have to contact me (send me your Amazon/Alexa email), in order to be included in.
 
-Also note, that Amazon has made Video Skills available only to US, UK, and DE countries. So you will have to switch country in Amazon settings in order to be able to use this skill.
+Also note, that Amazon has made Video Skills available only to US, UK, DE and ES countries. So you will have to switch country in Amazon settings in order to be able to use this skill.
 
 ## Working features
 *as of version 0.1.8 of the addon*


### PR DESCRIPTION
Added "ES" (Spain) because is already compatible with video Skill in Amazon Developer Console.